### PR TITLE
Tag clash in building documentation on NixOs

### DIFF
--- a/doc/nvim-runscript.txt
+++ b/doc/nvim-runscript.txt
@@ -1,4 +1,4 @@
-*nvim-runscript* NeoVim users, you may not need Postman
+*nvim-runscript.txt* NeoVim users, you may not need Postman
 
 Author: Klesh Wong <klesh@qq.com>
 


### PR DESCRIPTION
I believe there is a clash in documentation building on NixOs. The build fails with

```
       last 10 log lines:
       > configuring
       > no configure script, doing nothing
       > building
       > no Makefile, doing nothing
       > installing
       > post-installation fixup
       > Executing vimPluginGenTags
       > Building help tags
       > Error detected while processing command line:
       > E154: Duplicate tag "nvim-runscript" in file /nix/store/89y0fx5df7kxmaajzhhcw4kr6hn8v3fz-vimplugin-nvim-runscript/./doc/nvim-runscript.txtFailed to build help tags!
```